### PR TITLE
adding files back in for twiki examples

### DIFF
--- a/CMGTools/TTHAnalysis/python/plotter/susy-1lep/1l_CutFlowBasicPlots.txt
+++ b/CMGTools/TTHAnalysis/python/plotter/susy-1lep/1l_CutFlowBasicPlots.txt
@@ -1,0 +1,8 @@
+MET:     MET                                : 40,0,1200;  XTitle="MET [GeV]"
+MET_log:     MET                                : 40,0,1200;  XTitle="MET [GeV]", Logy
+HT:     HT                                : 40,0,3000;  XTitle="H_{T} [GeV]"
+HT_log:     HT                                : 40,0,3000;  XTitle="H_{T} [GeV]", Logy
+LT:     ST  : 40,0,1200;  XTitle="L_{T} [GeV]", Logy
+nJet:       nJets30Clean                            : 20,0,20   ;  XTitle="jet multiplicity"
+nJet_log:       nJets30Clean                            : 20,0,20   ;  XTitle="jet multiplicity", Logy
+

--- a/CMGTools/TTHAnalysis/python/plotter/susy-1lep/1l_basicCutsFullCutFlow.txt
+++ b/CMGTools/TTHAnalysis/python/plotter/susy-1lep/1l_basicCutsFullCutFlow.txt
@@ -1,0 +1,16 @@
+1 hard lep: nLep == 1 && Lep_pt > 25 && nVeto == 0
+Selected: Selected == 1
+Trigger: !isData || (isData && (HLT_EleHT350 || HLT_MuHT350))
+# use the following line to pick leptons only from the corresponding PD
+XOR: !isData || (isData && ((PD_SingleEle && nEl==1) || (PD_SingleMu && nMu==1)))
+Filters: !isData || (isData && Flag_goodVertices && Flag_HBHENoiseFilter_fix && Flag_CSCTightHaloFilter && Flag_eeBadScFilter && Flag_HBHENoiseIsoFilter && passCSCFilterList )
+
+nJetBase: nJets30Clean >= 5
+2.JetPt > 80: Jet2_pt > 80
+triggHT: HT > 500
+triggLT: LT > 250
+
+
+nbjets >= 1: nBJet >= 1
+njets >=6: nJets30Clean >= 6
+dphi > x: isSR == 1

--- a/CMGTools/TTHAnalysis/python/plotter/susy-1lep/mca-Spring15_1l_noPU.txt
+++ b/CMGTools/TTHAnalysis/python/plotter/susy-1lep/mca-Spring15_1l_noPU.txt
@@ -1,0 +1,74 @@
+#inclusive lpuow stats sample
+#TTincl 	 : TTJets_LO : xsec*1.0  ; FillColor=ROOT.kBlue-4, Label="t\#bar{t}"
+
+############################
+#Comment in for bins yields
+#TTbar combined from semi, dilep, and full and different HT bins
+#dileptonic
+#TT        : TTJets_DiLepton         : xsec*1 : lheHTIncoming <= 600; FillColor=ROOT.kBlue, Label="t\#bar{t} dilept"
+# wrote real xsec because mixed xsec in samples, semileptonic
+#TT      : TTJets_SingleLeptonFromT       : 182.1754*1 : lheHTIncoming <= 600; FillColor=ROOT.kBlue, Label="t\#bar{t} semilept"
+#TT     : TTJets_SingleLeptonFromTbar     : 182.1754*1 : lheHTIncoming <= 600; FillColor=ROOT.kBlue, Label="t\#bar{t} semilept"
+#full hadronic from inclusive sample
+#TT 	 : TTJets_LO : xsec*1 : ngenTau+ngenLep == 0 && lheHTIncoming <= 600 && HT < 1250; FillColor=ROOT.kBlue, Label="t\#bar{t}"
+#HT bins
+#TT 	 : TTJets_LO_HT600to800 : xsec*1 ; FillColor=ROOT.kBlue, Label="t\#bar{t}"
+#TT 	 : TTJets_LO_HT800to1200 : xsec*1 ; FillColor=ROOT.kBlue, Label="t\#bar{t}"
+#TT 	 : TTJets_LO_HT1200to2500 : xsec*1; FillColor=ROOT.kBlue, Label="t\#bar{t}"
+#TT 	 : TTJets_LO_HT2500toInf : xsec*1 ; FillColor=ROOT.kBlue, Label="t\#bar{t}"
+##############################
+#dileptoic ttbar
+TTdiLep 	 : TTJets_DiLepton : xsec*1 : lheHTIncoming <= 600; FillColor=ROOT.kBlue, Label="t\#bar{t}"
+TTdiLep 	 : TTJets_LO_HT600to800 : xsec*1 : ngenTau+ngenLep ==2 ; FillColor=ROOT.kBlue, Label="t\#bar{t}"
+TTdiLep 	 : TTJets_LO_HT800to1200 : xsec*1 : ngenTau+ngenLep ==2; FillColor=ROOT.kBlue, Label="t\#bar{t}"
+TTdiLep 	 : TTJets_LO_HT1200to2500 : xsec*1 : ngenTau+ngenLep ==2; FillColor=ROOT.kBlue, Label="t\#bar{t}"
+TTdiLep 	 : TTJets_LO_HT2500toInf : xsec*1 : ngenTau+ngenLep ==2; FillColor=ROOT.kBlue, Label="t\#bar{t}"
+###############################
+#semileptonic ttbar
+TTrest      : TTJets_SingleLeptonFromT        : 182.1754*1 : lheHTIncoming <= 600; FillColor=ROOT.kBlue-4, Label="t\#bar{t} semilept"
+TTrest      : TTJets_SingleLeptonFromTbar     : 182.1754*1 : lheHTIncoming <= 600; FillColor=ROOT.kBlue-4, Label="t\#bar{t} semilept"
+TTrest 	 : TTJets_LO : xsec*1 : ngenTau+ngenLep == 0 && lheHTIncoming <= 600  && HT < 1250; FillColor=ROOT.kBlue, Label="t\#bar{t}"
+TTrest 	 : TTJets_LO_HT600to800 : xsec*1 : ngenTau+ngenLep <2  ; FillColor=ROOT.kBlue-4, Label="t\#bar{t}"
+TTrest 	 : TTJets_LO_HT800to1200 : xsec*1 : ngenTau+ngenLep <2 ; FillColor=ROOT.kBlue-4, Label="t\#bar{t}"
+TTrest 	 : TTJets_LO_HT1200to2500 : xsec*1 : ngenTau+ngenLep <2 ; FillColor=ROOT.kBlue-4, Label="t\#bar{t}"
+TTrest 	 : TTJets_LO_HT2500toInf : xsec*1 : ngenTau+ngenLep <2 ; FillColor=ROOT.kBlue-4, Label="t\#bar{t}"
+
+
+WJets    : WJetsToLNu_HT100to200 :  xsec*1  ; Label="W+jets", FillColor=ROOT.kGreen-2
+WJets    : WJetsToLNu_HT200to400 :  xsec*1  ; Label="W+jets", FillColor=ROOT.kGreen-2
+WJets    : WJetsToLNu_HT400to600 :  xsec*1  ; Label="W+jets", FillColor=ROOT.kGreen-2
+WJets    : WJetsToLNu_HT600to800 :  xsec*1  ; Label="W+jets", FillColor=ROOT.kGreen-2
+WJets    : WJetsToLNu_HT800to1200 :  xsec*1  ; Label="W+jets", FillColor=ROOT.kGreen-2
+WJets    : WJetsToLNu_HT1200to2500 :  xsec*1  ; Label="W+jets", FillColor=ROOT.kGreen-2
+WJets    : WJetsToLNu_HT2500toInf :  xsec*1  ; Label="W+jets", FillColor=ROOT.kGreen-2
+
+# QCD (25ns)
+QCD      : QCD_HT300to500         : xsec*1 ; Label ="QCD", FillColor=ROOT.kCyan-6
+QCD      : QCD_HT500to700         : xsec*1 ; Label ="QCD", FillColor=ROOT.kCyan-6
+QCD      : QCD_HT700to1000         : xsec*1 ; Label ="QCD", FillColor=ROOT.kCyan-6
+QCD      : QCD_HT1000to1500         : xsec*1 ; Label ="QCD", FillColor=ROOT.kCyan-6
+QCD      : QCD_HT1500to2000         : xsec*1 ; Label ="QCD", FillColor=ROOT.kCyan-6
+QCD      : QCD_HT2000toInf         : xsec*1 ; Label ="QCD", FillColor=ROOT.kCyan-6
+
+SingleT  : TToLeptons_tch_amcatnlo_full	 : xsec*1 ; FillColor = ROOT.kViolet+5, Label= "t/\#bar{t}"
+SingleT  : TToLeptons_sch	 : xsec*1 ; FillColor = ROOT.kViolet+5, Label= "t/\#bar{t}"
+SingleT  : T_tWch	 : xsec*1 ; FillColor = ROOT.kViolet+5, Label= "t/\#bar{t}"
+SingleT  : TBar_tWch	 : xsec*1 ; FillColor = ROOT.kViolet+5, Label= "t/\#bar{t}"
+
+
+DY       : DYJetsToLL_M50_HT100to200 :  xsec*1 ; Label="DY+jets", FillColor=ROOT.kRed-6, NormSystematic=0.5
+DY       : DYJetsToLL_M50_HT200to400 :   xsec*1 ; Label="DY+jets", FillColor=ROOT.kRed-6, NormSystematic=0.5
+DY       : DYJetsToLL_M50_HT400to600 :    xsec*1 ; Label="DY+jets", FillColor=ROOT.kRed-6, NormSystematic=0.5
+DY       : DYJetsToLL_M50_HT600toInf :    xsec*1 ; Label="DY+jets", FillColor=ROOT.kRed-6, NormSystematic=0.5
+
+TTV : TTWToLNu : xsec*1 ; FillColor=ROOT.kOrange-3, Label="ttV(W/Z/H)", NormSystematic=0.2
+TTV : TTWToQQ : xsec*1 ; FillColor=ROOT.kOrange-3, Label="ttV(W/Z/H)", NormSystematic=0.2
+TTV : TTZToLLNuNu : xsec*1 ; FillColor=ROOT.kOrange-3, Label="ttV(W/Z/H)", NormSystematic=0.2
+TTV : TTZToQQ : xsec*1 ; FillColor=ROOT.kOrange-3, Label="ttV(W/Z/H)", NormSystematic=0.2
+
+
+#data: SingleElectron_Run2015D_05Oct
+#data: SingleElectron_Run2015D_v4
+
+#data: SingleMuon_Run2015D_05Oct
+#data: SingleMuon_Run2015D_v4


### PR DESCRIPTION
Updated twiki https://twiki.cern.ch/twiki/bin/view/CMS/SUSYCMGFwkPlotSingleLepton74X with latest examples.

The currently used samples (as of 18.12.2015) are soft linked here on the NAF. These have the trigger skim already applied, meaning 1 lepton, HT and LT.
- Data/MC:
  - ntuples: /afs/desy.de/user/l/lobanov/public/CMG/SampLinks/SampLinks_MiniAODv2_skimmed/
  - data friendtrees: /afs/desy.de/user/l/lobanov/public/CMG/SampLinks/SampLinks_MiniAODv2_skimmed/Friends/Data/trig_base_skim_2p1fb/
  - MC friendtrees: /afs/desy.de/user/l/lobanov/public/CMG/SampLinks/SampLinks_MiniAODv2_skimmed/Friends/MC/pu_69mb/
- Signal:
  - ntuples: /afs/desy.de/user/l/lobanov/public/CMG/SampLinks/SampLinks_MiniAODv2_skimmed/Signal
  - friends: /afs/desy.de/user/l/lobanov/public/CMG/SampLinks/SampLinks_MiniAODv2_skimmed/Signal/FullScanSkim/Friends
